### PR TITLE
added movement vector for water shader

### DIFF
--- a/hbt-server/public/shaders/water.frag
+++ b/hbt-server/public/shaders/water.frag
@@ -18,17 +18,20 @@ precision mediump float;
 
 uniform vec2      resolution;
 uniform float     time;
+uniform vec2      movement;
 
 void main(void) 
 {
 	float ptime = time * .5+23.0;
     // uv should be the 0-1 uv of texture...
 	vec2 uv = gl_FragCoord.xy / resolution; // iResolution.xy;
+
+  uv -= movement * time * 0.1;
     
 #ifdef SHOW_TILING
 	vec2 p = mod(uv*TAU*2.0, TAU)-250.0;
 #else
-    vec2 p = mod(uv*TAU, TAU)-250.0;
+  vec2 p = mod(uv*TAU, TAU)-250.0;
 #endif
 	vec2 i = vec2(p);
 	float c = 1.0;


### PR DESCRIPTION
To pass the movement vector, use this code when creating the scene:
```
  const shader = this.add.shader(layer.key, position.x, position.y, dimensions.width, dimensions.height);
  shader.shader.uniforms = {};
  shader.shader.uniforms.movement = { type: '2f', value: { x: 1.0, y: 1.0 } };
  shader.setShader(shader.shader);
```

I could not find another way of passing a custom uniform that didn't give an error.

the vector is the direction the water flows, positive `y` is down, positive `x` is right.

edit: also, the vector doesn't get normalized, so you can make the water faster/slower with a bigger/smaller vector.